### PR TITLE
chore(*): refactor to be alpine-based

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.0
+VERSION := 0.1.0-alpine
 REGISTRY ?= quay.io
 IMAGE_PREFIX ?= deis/
 IMAGE := ${REGISTRY}/${IMAGE_PREFIX}go-dev:${VERSION}

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 docker-go-dev is the source for the `deis/go-dev` Docker image available at [quay.io](https://quay.io).
 
+__NOTE: This is an _experimental_ branch that bases the dev environment on Alpine Linux in order to promote a smaller image size.  Alpine's `libc` implementation is purported to be non-standard and problematic.  Your mileage from this branch, or the Docker image built from it, may vary.__
+
 Its purpose is to provide a lightweight Go development environment for use by Deis contributors.  Many Deis component builds delegate to containers based on this image, thereby eliminating the need for contributors to install and manage any specific set of development tools and version thereof.
 
 At present the image just contains:
 
-* go (from the golang:1.5.1 image)
+* go (from the official golang:1.5.1-alpine image)
+* Additional packages:
+  * openssl
+	* build-base
+	* git
+	* mercurial (with some minimal configuration)
 * glide (for go dependency management)
 
 Although created for use with Deis development, this image may prove generally useful to the Go community.

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,7 +1,9 @@
-FROM golang:1.5.1
+FROM golang:1.5.1-alpine
 
 ENV GO15VENDOREXPERIMENT=1
 ENV GLIDE_HOME=/root
+
+RUN apk add openssl build-base git mercurial --update-cache
 
 WORKDIR /tmp
 


### PR DESCRIPTION
This cuts 300mb of bloat from the dev environment.  I've bumped the version number as well, as I'd like to push this as `quay.io/deis/go-dev:0.2.0`.

Ping @technosophos @arschles