### PR TITLE
style(Dockerfile): Squash glide RUN commands into one layer

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,13 +5,10 @@ ENV GLIDE_HOME=/root
 
 WORKDIR /tmp
 
-RUN wget https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz
-
-RUN tar xvfz glide-0.7.2-linux-amd64.tar.gz
-
-RUN mv linux-amd64/glide /usr/local/bin/
-
-RUN rm -rf linux-amd64 glide-0.7.2-linux-amd64.tar.gz
+RUN wget https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz && \
+    tar xvfz glide-0.7.2-linux-amd64.tar.gz && \
+    mv linux-amd64/glide /usr/local/bin/ && \
+    rm -rf linux-amd64 glide-0.7.2-linux-amd64.tar.gz
 
 WORKDIR /go
 


### PR DESCRIPTION
`RUN` commands for a given task (i.e. installing a package) should be grouped into one layer.

This improves the style in two ways: Developers can at a single glance say "OK, this group of commands install _glide_"; And, of course, we get a smaller number of layer per image. 