### PR TITLE
feat(image): add golint and bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.1.0
+VERSION := 0.2.0
 REGISTRY ?= quay.io
 IMAGE_PREFIX ?= deis/
 IMAGE := ${REGISTRY}/${IMAGE_PREFIX}go-dev:${VERSION}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,6 +13,8 @@ RUN mv linux-amd64/glide /usr/local/bin/
 
 RUN rm -rf linux-amd64 glide-0.7.2-linux-amd64.tar.gz
 
+RUN go get -u -v github.com/golang/lint/golint
+
 WORKDIR /go
 
 COPY . /


### PR DESCRIPTION
fwiw, the need for a newer version of this that support golint is blocking upcoming router PRs.