### PR TITLE
feat(Dockerfile): upgrade to glide version 0.8.1

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,10 +5,10 @@ ENV GLIDE_HOME=/root
 
 WORKDIR /tmp
 
-RUN wget https://github.com/Masterminds/glide/releases/download/0.8.0/glide-0.8.0-linux-amd64.tar.gz && \
-  tar xvfz glide-0.8.0-linux-amd64.tar.gz && \
+RUN wget https://github.com/Masterminds/glide/releases/download/0.8.1/glide-0.8.1-linux-amd64.tar.gz && \
+  tar xvfz glide-0.8.1-linux-amd64.tar.gz && \
   mv linux-amd64/glide /usr/local/bin/ && \
-  rm -rf linux-amd64 glide-0.8.0-linux-amd64.tar.gz
+  rm -rf linux-amd64 glide-0.8.1-linux-amd64.tar.gz
 
 RUN go get -u -v github.com/golang/lint/golint
 


### PR DESCRIPTION
I'd also like us to consider tagging this as a `0.3.0` feature release after this is merged.  Why a feature release?  Because glide 0.8.0+ has support for `glide.lock` files and that new glide feature constitutes a new capability for this image-- one that I think people would like to start using.