### PR TITLE
ref(Makefile): remove trailing slash from IMAGE_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
 REGISTRY ?= quay.io/
-IMAGE_PREFIX ?= deis/
-IMAGE := ${REGISTRY}${IMAGE_PREFIX}go-dev:${VERSION}
+IMAGE_PREFIX ?= deis
+IMAGE := ${REGISTRY}${IMAGE_PREFIX}/go-dev:${VERSION}
 
 build:
 	docker build -t ${IMAGE} rootfs


### PR DESCRIPTION
This change matches what other deis repos do, and keeps the build environment consistent.

cc/ @krancour 