### PR TITLE
chore(rootfs/Dockerfile): upgrade to glide 0.9.0-RC 1

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update && apt-get install -y \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/Masterminds/glide/releases/download/0.8.3/glide-0.8.3-linux-amd64.tar.gz && \
-  tar xvfz glide-0.8.3-linux-amd64.tar.gz && \
+RUN wget https://github.com/Masterminds/glide/releases/download/0.9.0-rc1/glide-0.9.0-rc1-linux-amd64.tar.gz && \
+  tar xvfz glide-0.9.0-rc1-linux-amd64.tar.gz && \
   mv linux-amd64/glide /usr/local/bin/ && \
-  rm -rf linux-amd64 glide-0.8.3-linux-amd64.tar.gz
+  rm -rf linux-amd64 glide-0.9.0-rc1-linux-amd64.tar.gz
 
 RUN go get -u -v \
   github.com/golang/lint/golint \


### PR DESCRIPTION
This replaces the older, 0.8.3 version of [glide](https://github.com/Masterminds/glide) with the newer [0.9.0 Release Candidate 1 version](https://github.com/Masterminds/glide/releases/tag/0.9.0-rc1)