### PR TITLE
ref(Dockerfile): switch to alpine-based image

### DIFF
--- a/rootfs/.dockerignore
+++ b/rootfs/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,26 +1,15 @@
-FROM golang:1.6.0
+FROM golang:1.6-alpine
 
 ENV GO15VENDOREXPERIMENT=1
 ENV GLIDE_HOME=/root
 
-WORKDIR /tmp
-
-RUN apt-get update && apt-get install -y \
-  upx \
-  --no-install-recommends \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN wget https://github.com/Masterminds/glide/releases/download/0.9.3/glide-0.9.3-linux-amd64.tar.gz && \
-  tar xvfz glide-0.9.3-linux-amd64.tar.gz && \
-  mv linux-amd64/glide /usr/local/bin/ && \
-  rm -rf linux-amd64 glide-0.9.3-linux-amd64.tar.gz
-
-RUN go get -u -v \
-  github.com/golang/lint/golint \
-  github.com/onsi/ginkgo/ginkgo \
-  github.com/pwaller/goupx \
-  github.com/mitchellh/gox
-
-WORKDIR /go
-
-COPY . /
+ADD https://github.com/lalyos/docker-upx/releases/download/v3.91/upx /usr/local/bin/upx
+RUN chmod +x /usr/local/bin/upx \
+    && apk -U add bzr git mercurial tar \
+    && go get -u -v \
+      github.com/golang/lint/golint \
+      github.com/onsi/ginkgo/ginkgo \
+      github.com/pwaller/goupx \
+      github.com/mitchellh/gox \
+    && curl -sSL https://github.com/Masterminds/glide/releases/download/0.9.3/glide-0.9.3-linux-amd64.tar.gz \
+      | tar -vxz -C /usr/local/bin --strip=1


### PR DESCRIPTION
This reduces the size of the Docker image from 809.4 to 394 MB.

See also deis/docker-python-dev#10.