### PR TITLE
feat(image): Add man package

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -6,6 +6,7 @@ ENV GLIDE_HOME=/root
 WORKDIR /tmp
 
 RUN apt-get update && apt-get install -y \
+  man \
   upx \
   zip \
   --no-install-recommends \


### PR DESCRIPTION
Some of the projects that are using this image to containerize their builds and various other make targets sometimes include a target like `make dev` or `make dev-env` that drops a developer interactively at a prompt within the container...

`man` is simply a generally useful tool to have available to developers who may at times step into the containerized dev environment as described above.