### PR TITLE
feat(test-cover.sh): add go code coverage test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 services:
   - docker
 
-script: make build
+script: make build test
 
 deploy:
   provider: script

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ IMAGE_PREFIX ?= deis
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/go-dev:${VERSION}
 
 # scripts are checked *after* build, so use paths inside the container
-SHELL_SCRIPTS = /usr/local/bin/gen-changelog.sh
+SHELL_SCRIPTS = /usr/local/bin/gen-changelog.sh /usr/local/bin/test-cover.sh
 
 # dockerized development environment variables
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ creating [issues][] and submitting [pull requests][].
 * [golint][]: go source code linter
 * [gox][]: simple go cross-compiling tool
 * [shellcheck][]: static analysis for shell scripts
+* [test-cover.sh][]: test coverage for multiple go packages
 * [upx][]: executable packer
 
 ## Usage
@@ -58,4 +59,5 @@ The latest deis/go-dev Docker image is available at:
 [pull requests]: https://github.com/deis/docker-go-dev/pulls
 [Quay.io]: https://quay.io
 [shellcheck]: https://github.com/koalaman/shellcheck
+[test-cover.sh]: https://github.com/deis/docker-go-dev/tree/master/rootfs/usr/local/bin/test-cover.sh
 [upx]: http://upx.sourceforge.net/

--- a/rootfs/usr/local/bin/test-cover.sh
+++ b/rootfs/usr/local/bin/test-cover.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck disable=SC2046
+pkgs=$(go list $(glide novendor))
+
+echo "" > coverage.txt
+for p in $pkgs; do
+    go test -covermode=atomic -coverprofile=profile.out "$p"
+    if [ -s profile.out ]; then
+        cat profile.out >> coverage.txt
+    fi
+    rm -f profile.out
+done


### PR DESCRIPTION
This adapts the [script recommended by codecov.io](https://github.com/codecov/example-go#caveat-multiple-files) to use `glide novendor` and to pass `shellcheck`. 

`test-cover.sh` can be called from project Makefiles to run tests recursively and concatenate a master `coverage.txt` file. For example, add it to a Makefile target:
```Makefile
test-cover:
    ${DEV_ENV_CMD} test-cover.sh
```
Then add `coverage.txt` to `.gitignore` and invoke test-cover:
```console
$ make test-cover
docker run --rm -e GO15VENDOREXPERIMENT=1 -v /Users/matt/Projects/src/github.com/deis/builder:/go/src/github.com/deis/builder -w /go/src/github.com/deis/builder quay.io/deis/go-dev:latest test-cover.sh
?   	github.com/deis/builder/pkg	[no test files]
ok  	github.com/deis/builder/pkg/cleaner	5.017s	coverage: 84.6% of statements
?   	github.com/deis/builder/pkg/conf	[no test files]
ok  	github.com/deis/builder/pkg/controller	0.020s	coverage: 27.3% of statements
ok  	github.com/deis/builder/pkg/env	0.009s	coverage: 100.0% of statements
ok  	github.com/deis/builder/pkg/git	0.024s	coverage: 4.9% of statements
ok  	github.com/deis/builder/pkg/gitreceive	0.078s	coverage: 20.4% of statements
ok  	github.com/deis/builder/pkg/healthsrv	0.027s	coverage: 85.5% of statements
?   	github.com/deis/builder/pkg/k8s	[no test files]
ok  	github.com/deis/builder/pkg/sshd	1.699s	coverage: 65.6% of statements
ok  	github.com/deis/builder/pkg/storage	0.016s	coverage: 51.6% of statements
?   	github.com/deis/builder/pkg/sys	[no test files]
?   	github.com/deis/builder	[no test files]
$ ls -alh coverage.txt 
-rw-r--r--  1 matt  staff    28K Apr 24 12:31 coverage.txt
$ head coverage.txt 

mode: atomic
github.com/deis/builder/pkg/cleaner/cleaner.go:23.74,25.16 2 1
github.com/deis/builder/pkg/cleaner/cleaner.go:28.2,28.6 1 1
github.com/deis/builder/pkg/cleaner/cleaner.go:25.16,27.3 1 0
github.com/deis/builder/pkg/cleaner/cleaner.go:28.6,29.10 1 87915699
github.com/deis/builder/pkg/cleaner/cleaner.go:30.3,31.11 1 87916906
github.com/deis/builder/pkg/cleaner/cleaner.go:34.4,34.31 1 7
github.com/deis/builder/pkg/cleaner/cleaner.go:31.11,32.10 1 87918462
github.com/deis/builder/pkg/cleaner/cleaner.go:34.31,35.32 1 3
```

The `coverage.txt` file should be ready for feeding to https://codecov.io at that point, but I could use help testing that assumption from someone who has done that integration.

cc: @arschles @helgi 

Refs deis/builder#218, deis/builder#258, deis/builder#277, deis/minio#66.