### PR TITLE
feat(gen-changelog.sh): add CHANGELOG.md generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,18 @@ REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= deis
 IMAGE := ${REGISTRY}${IMAGE_PREFIX}/go-dev:${VERSION}
 
+# scripts are checked *after* build, so use paths inside the container
+SHELL_SCRIPTS = /usr/local/bin/gen-changelog.sh
+
+# dockerized development environment variables
+DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1
+DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${IMAGE}
+
 build:
 	docker build -t ${IMAGE} rootfs
 
 push: build
 	docker push ${IMAGE}
+
+test: build
+	${DEV_ENV_CMD} shellcheck $(SHELL_SCRIPTS)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ creating [issues][] and submitting [pull requests][].
 ## Image Contents
 
 * based on the [official go Docker image][]
+* [gen-changelog.sh][]: generate updates to CHANGELOG.md
 * [ginkgo][]: BDD testing framework for go
 * [glide][]: go dependency management
 * [golint][]: go source code linter
@@ -46,6 +47,7 @@ The latest deis/go-dev Docker image is available at:
 
 [Deis Workflow]: https://deis.com/
 [Docker Hub]: https://hub.docker.com
+[gen-changelog.sh]: https://github.com/deis/docker-go-dev/tree/master/rootfs/usr/local/bin/gen-changelog.sh
 [ginkgo]: https://github.com/onsi/ginkgo
 [glide]: https://github.com/Masterminds/glide
 [Go]: https://golang.org/

--- a/rootfs/usr/local/bin/gen-changelog.sh
+++ b/rootfs/usr/local/bin/gen-changelog.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Prints a Markdown-formatted summary of git commits ready to include in
+# a CHANGELOG.md file
+#
+# Usage: gen-changelog.sh [from] [to]
+# If no [from] argument is supplied, uses the most recent git tag.
+# if no [to] argument is supplied, uses git HEAD.
+#
+# The REPOROOT and TYPES variables may be used to customize what links are
+# generated and what is scraped from the commit logs.
+
+set -euo pipefail
+
+PACKAGE=${PACKAGE:=$(go list .)}
+REPOROOT=${REPOROOT:=https://$PACKAGE}
+TYPES=${TYPES:=feat(;Features fix(;Fixes docs(;Documentation chore(;Maintenance}
+
+# Print the information scraped from git
+retrieve() {
+    while read -r commit hash message; do
+        # Extract the subsystem where type(subsystem): message
+        SUBSYSTEM=$(echo "$message" | cut -d'(' -f2 | cut -d')' -f1 | sed 's/\*/\(all\)/g')
+        # Extract the message where type(subsystem): message
+        MESSAGE=$(echo "$message" | awk -F ")" '{ print $2}' | sed 's/://' | cut -f2- -d' ')
+        # Generate a link to the full legal commit on GitHub
+        LINK="$REPOROOT/commit/$hash"
+        # Echo all this in a way that makes the commit hash and message a link
+        # to the commit in markdown
+        echo ' -' "[\`$commit\`]($LINK)" "$SUBSYSTEM": "$MESSAGE"
+    done < <(git --no-pager log --oneline --merges --oneline --format="%h %H %b" --grep="$1" "$FROM".."$TO")
+    # Scrape the information from git
+}
+
+# Wrap feature type and show its relevant commits
+subheading() {
+    echo "#### $1"
+    echo
+    retrieve "$2"
+    echo
+}
+
+main() {
+    FROM=${1:-$(git describe --abbrev=0 --tags)}
+    TO=${2:-"HEAD"}
+    RELEASE=${RELEASE:=$TO}
+
+    printf "### %s -> %s\n\n" "$FROM" "$RELEASE"
+
+    # Iterate over the types of messages specified
+    for LEGALTYPE in $TYPES; do
+        SHORT=$(echo "$LEGALTYPE" | cut -f1 -d';')
+        LONG=$(echo "$LEGALTYPE" | cut -f2 -d';')
+        subheading "$LONG" "$SHORT"
+    done
+}
+
+if [ $SHLVL -eq 1 ] || [ $SHLVL -eq 2 ]; then
+    # If this is being run as a command
+    main "$@"
+    >&2 echo -e "\033[0;33mBe sure to change headers, remove empty sections,"
+    >&2 echo -e "and proofread before committing to CHANGELOG.md.\033[0m"
+else
+    # Otherwise this is being sourced
+    unset -f main
+    unset -f usage
+fi


### PR DESCRIPTION
This more flexible version in the standard go-dev image lets components remove the copy-pasted `_scripts/generate-changelog.sh`.

Add a Makefile target and go:
```Makefile
gen-changelog:
    ${DEV_ENV_CMD} gen-changelog.sh
```
```console
$ make gen-changelog
docker run --rm -e GO15VENDOREXPERIMENT=1 -v /Users/matt/Projects/src/github.com/deis/builder:/go/src/github.com/deis/builder -w /go/src/github.com/deis/builder quay.io/deis/go-dev:latest gen-changelog.sh
### v2.0.0-beta2 -> HEAD

#### Features

 - [`514d0e3`](https://github.com/deis/builder/commit/514d0e3f604de5ddb2450d0b7a5b5729325573e8) pkg/sshd: Store private keys in kubernetes secret

#### Fixes

 - [`1c37d86`](https://github.com/deis/builder/commit/1c37d86feae5925f430c2825c81abc5104cc1453) sshd: log incoming env request to debug level
 - [`cd259f8`](https://github.com/deis/builder/commit/cd259f86e547996944f6312d5e0dc2fe43c19ded) slugbuilder: check for the succeded status while waiting for slugbuilder pod
 - [`ab88b54`](https://github.com/deis/builder/commit/ab88b5412c9e7f848dc57de060f7215e8dc66e1b) bug: use the deis time which supports RFC3339 dates
 - [`7701533`](https://github.com/deis/builder/commit/7701533b0a8cb334bdf9a18547db08d6efc62ff3) .github: rename docs-v2 to workflow

#### Documentation


#### Maintenance

 - [`2a9db63`](https://github.com/deis/builder/commit/2a9db634a43427057f783a063ea122275c18f322) .travis.yml: Deep six the travis -> jenkins webhooks

Be sure to change headers, remove empty sections,
and proofread before committing to CHANGELOG.md.
```