### PR TITLE
chore(Dockerfile): remove goupx for go 1.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The go-dev docker container provides a lightweight Go development environment fo
 * [glide](https://github.com/Masterminds/glide): go dependency management
 * [golint](https://github.com/golang/lint): go source code linter
 * [ginkgo](https://github.com/onsi/ginkgo): BDD testing framework for go
-* [goupx](https://github.com/pwaller/goupx): go-compatible executable packer
+* [upx](http://upx.sourceforge.net/): executable packer
 * [gox](https://github.com/mitchellh/gox): simple go cross-compiling tool
 
 ## Usage

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update && apt-get install -y \
   && go get -u -v \
   github.com/golang/lint/golint \
   github.com/onsi/ginkgo/ginkgo \
-  github.com/pwaller/goupx \
   github.com/mitchellh/gox
 
 WORKDIR /go


### PR DESCRIPTION
It is [no longer needed](https://github.com/pwaller/goupx#update-20160310) as `upx` can handle go 1.6 binaries.