### PR TITLE
fix(.travis.yml): allow deploy on git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script: make build
 deploy:
   provider: script
   script: _scripts/ci/deploy.sh
+  on:
+    tags: true


### PR DESCRIPTION
The `deploy` step has been consistently skipped because Travis reports
> Skipping a deployment with the script provider because this branch is not permitted

I think this will fix it based on other Workflow repository configs that were working.