### PR TITLE
fix(dockerfiles): create files with same uid as jenkins

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,6 +2,14 @@ FROM golang:1.6.3
 
 ENV GLIDE_VERSION=v0.11.0 GLIDE_HOME=/root GO15VENDOREXPERIMENT=1
 
+RUN addgroup --gid 999 godev
+RUN adduser --system \
+	--shell /bin/bash \
+	--disabled-password \
+	--gid 999 \
+	--uid 999 \
+	godev
+
 RUN apt-get update && apt-get install -y \
   jq \
   man \
@@ -21,3 +29,5 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /go
 
 COPY . /
+
+USER godev


### PR DESCRIPTION
This should allow the jenkins user to actually delete the files created by the docker container.

I don't have ssh access to the build slaves, but this is identical to work done in places like deis/docker-shell-dev.

Ping @vdice @jchauncey, who have experience with this.