### PR TITLE
fix(dockerfiles): revert create files with same uid as jenkins

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,14 +2,6 @@ FROM golang:1.6.3
 
 ENV GLIDE_VERSION=v0.11.1 GLIDE_HOME=/root GO15VENDOREXPERIMENT=1
 
-RUN addgroup --gid 999 godev
-RUN adduser --system \
-	--shell /bin/bash \
-	--disabled-password \
-	--gid 999 \
-	--uid 999 \
-	godev
-
 RUN apt-get update && apt-get install -y \
   jq \
   man \
@@ -29,5 +21,3 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /go
 
 COPY . /
-
-USER godev


### PR DESCRIPTION
This turned out to be brittle on computers that aren't jenkins (like developers machine).