### PR TITLE
Proposal: feat(linters): switch to gometalinter

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,9 +14,10 @@ RUN apt-get update && apt-get install -y \
   && curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-0.4.3-linux-amd64 -o /usr/local/bin/shellcheck \
   && chmod +x /usr/local/bin/shellcheck \
   && go get -u -v \
-  github.com/golang/lint/golint \
+  github.com/alecthomas/gometalinter \
   github.com/onsi/ginkgo/ginkgo \
-  github.com/mitchellh/gox
+  github.com/mitchellh/gox \
+  && gometalinter --install
 
 WORKDIR /go
 

--- a/rootfs/usr/local/bin/lint
+++ b/rootfs/usr/local/bin/lint
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Mandatory tests
+gometalinter --vendor --tests --deadline=20s --disable-all \
+--enable=gofmt \
+--enable=misspell \
+--enable=deadcode \
+--enable=ineffassign \
+--enable=gosimple \
+--enable=vet \
+./...
+
+mandatory=$?
+
+# Optional tests
+gometalinter --vendor --tests --deadline=20s --disable-all \
+--enable=golint \
+./...
+
+exit $mandatory


### PR DESCRIPTION
[Gometalinter](https://github.com/alecthomas/gometalinter) is a linter that combines the most popular linters together.

It contains the linters we already use: `go vet`, `gofmt`, and `golint`, but also many more useful ones, such as the ones used by [goreportcard](https://goreportcard.com/report/github.com/deis/controller-sdk-go). It also runs them in parallel, so it shouldn't incur a large performance penalty.

It also prints out standardized output for all linters and returns error codes, so we don't have to use the hacks we use with gofmt to get a proper error code. It's also smart about the input format of packages, so we can just run `gometalinter ./...` and not have to worry about keeping lists of packages and go files to run the linter on, reducing makefile maintenance.