### PR TITLE
feat(Dockerfile): base off deis/base

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,14 +1,20 @@
-FROM golang:1.7
+FROM quay.io/deis/base:0.3.1
 
-ENV GLIDE_VERSION=v0.11.1 GLIDE_HOME=/root
+ENV GO_VERSION=1.7 \
+    GLIDE_VERSION=v0.11.1 \
+    GLIDE_HOME=/root \
+    PATH=$PATH:/usr/local/go/bin:/go/bin \
+    GOPATH=/go
 
 RUN apt-get update && apt-get install -y \
   jq \
   man \
   upx \
   zip \
+  git \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
+  && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 \
   && curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-0.4.3-linux-amd64 -o /usr/local/bin/shellcheck \


### PR DESCRIPTION
This allows us to share the same base image as everything else. In addition, the `golang` image wasn't very slimed down, so we shrink size from 294 MB -> 180 MB