### PR TITLE
feat(k8s-claimer): Add latest k8s-claimer to the toolbox

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y \
     | tar -vxz -C /usr/local/bin --strip=1 \
   && curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-0.4.3-linux-amd64 -o /usr/local/bin/shellcheck \
   && chmod +x /usr/local/bin/shellcheck \
+  && curl -L https://storage.googleapis.com/k8s-claimer/git-e4dcc16/k8s-claimer-git-e4dcc16-linux-amd64 -o /usr/local/bin/k8s-claimer \
+	&& chmod +x /usr/local/bin/k8s-claimer \
   && go get -u -v \
   github.com/alecthomas/gometalinter \
   github.com/onsi/ginkgo/ginkgo \


### PR DESCRIPTION
I'd like to include k8s-claimer in the toolbox for easy use by any of our own projects that have a specific need to lease a cluster to facilitate e2e or integration tests.

cc @mboersma @arschles 