### PR TITLE
fix(Dockerfile): add missing build tools

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
   git \
   gcc \
   make \
+  mercurial \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
   upx \
   zip \
   git \
+  gcc \
+  make \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \


### PR DESCRIPTION
Some useful tools were inadvertently lost when refactoring to [use deis/docker-base](https://github.com/deis/docker-go-dev/pull/52).

See #57 for a different approach to fixing this.