### PR TITLE
feat(Dockerfile): base off deis/base

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,15 +1,23 @@
-FROM golang:1.7.1
+FROM quay.io/deis/base:v0.3.4
 
-ENV GLIDE_VERSION=v0.12.2 \
-    GLIDE_HOME=/root
+ENV GO_VERSION=1.7.1 \
+    GLIDE_VERSION=v0.12.2 \
+    GLIDE_HOME=/root \
+    PATH=$PATH:/usr/local/go/bin:/go/bin \
+    GOPATH=/go
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential \
+  git-core \
+  mercurial \
+  util-linux \
   jq \
   man \
   upx \
   zip \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
+  && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 \
   && curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-0.4.3-linux-amd64 -o /usr/local/bin/shellcheck \


### PR DESCRIPTION
Restores @Joshua-Anderson's code reverted in #57, adding some missing tools. The resulting image isn't small, but it's small*er*, and should require less network bandwidth for developers already working with images that start `FROM deis/base:0.3.1`:
```bash
$ docker images | grep go-dev
deis/go-dev           golang-171     24434dbeb1c2        2 minutes ago       833.1 MB
deis/go-dev           deis-base      c06a2930cb9d        11 minutes ago      705.7 MB
```
Note that this moves from debian/jessie to ubuntu/xenial, so projects that make assumptions about the base image--like [workflow-cli](https://github.com/deis/workflow-cli/blob/d6dadfe1f8090e1bee40690604043aa5ab86ea37/Dockerfile#L4)--will need to change when adopting a new deis/base that includes this.

See also #52 and #58.