### PR TITLE
feat(Dockerfile): update shellcheck to v0.4.6

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/deis/base:v0.3.6
 ENV GO_VERSION=1.7.5 \
     GLIDE_VERSION=v0.12.3 \
     GLIDE_HOME=/root \
+    SHELLCHECK_VERSION=v0.4.6 \
     PATH=$PATH:/usr/local/go/bin:/go/bin \
     GOPATH=/go
 
@@ -21,7 +22,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 \
-  && curl -L https://s3-us-west-2.amazonaws.com/get-deis/shellcheck-0.4.3-linux-amd64 -o /usr/local/bin/shellcheck \
+  && curl -L https://deisbuildartifacts.blob.core.windows.net/shellcheck/shellcheck-${SHELLCHECK_VERSION}-linux-amd64 -o /usr/local/bin/shellcheck \
   && chmod +x /usr/local/bin/shellcheck \
   && curl -L https://storage.googleapis.com/k8s-claimer/git-e4dcc16/k8s-claimer-git-e4dcc16-linux-amd64 -o /usr/local/bin/k8s-claimer \
 	&& chmod +x /usr/local/bin/k8s-claimer \


### PR DESCRIPTION
Also moves the `shellcheck` binary to Azure blob storage.