### PR TITLE
feat(gb): Adds the gb utility to the image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   github.com/mitchellh/gox \
   github.com/golang/protobuf/protoc-gen-go \
   github.com/golang/dep/cmd/dep \
+  github.com/constabulary/gb/... \
   && gometalinter --install
 
 WORKDIR /go


### PR DESCRIPTION
This utility is used on the ACS RP team for now to build all of their binaries. Adding it to this image lets me start containerizing their build