### PR TITLE
feat(rootfs/Dockerfile): Add openssh-client

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   unzip \
   upx \
   zip \
+  openssh-client \
   --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \


### PR DESCRIPTION
Adding the openssh client so this image can ssh into other things and generate ssh keys. This will be used particularly for the acs-engine e2e tests.