### PR TITLE
chore(rootfs/Dockerfile): update glide to 0.13.0

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/deis/base:v0.3.6
 
 ENV AZCLI_VERSION=2.0.14 \
     GO_VERSION=1.9.1 \
-    GLIDE_VERSION=v0.12.3 \
+    GLIDE_VERSION=v0.13.0 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.6.0 \
     KUBECTL_VERSION=v1.7.2 \


### PR DESCRIPTION
See https://github.com/Masterminds/glide/releases/tag/v0.13.0

The latest version of `dep` is also built into this image, btw.