### PR TITLE
chore(Dockerfile): use latest released version of `dep`

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -46,6 +46,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   && chmod +x /usr/local/bin/kubectl \
   && curl -sSL https://storage.googleapis.com/kubernetes-helm/helm-$HELM_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 \
+  && mkdir -p /go/bin \
+  && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
   && apt-get purge -y --auto-remove \
     unzip \
   && apt-get autoremove -y \
@@ -60,7 +62,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
   github.com/onsi/ginkgo/ginkgo \
   github.com/mitchellh/gox \
   github.com/golang/protobuf/protoc-gen-go \
-  github.com/golang/dep/cmd/dep \
   github.com/haya14busa/goverage \
   github.com/constabulary/gb/... \
   github.com/dgrijalva/jwt-go/cmd/jwt \


### PR DESCRIPTION
Pulling from master is considered dangerous for the `dep` vendoring tool, according to @carolynvs and the project's [README](https://github.com/golang/dep#installation). Currently this fetches v0.4.1:

```console
$ docker run -it quay.io/deis/go-dev:local dep version
dep:
 version     : v0.4.1
 build date  : 2018-01-24
 git hash    : 37d9ea0a
 go version  : go1.9.1
 go compiler : gc
 platform    : linux/amd64
```