### PR TITLE
chore(rootfs/Dockerfile): install gometalinter from stable tag

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -4,7 +4,6 @@ ENV AZCLI_VERSION=2.0.44 \
     GO_VERSION=1.11 \
     GLIDE_VERSION=v0.13.1 \
     GLIDE_HOME=/root \
-    GOMETALINTER_VERSION=2.0.5 \
     HELM_VERSION=v2.6.0 \
     KUBECTL_VERSION=v1.9.6 \
     SHELLCHECK_VERSION=v0.4.6 \
@@ -79,10 +78,9 @@ RUN \
     github.com/mitchellh/gox \
     github.com/onsi/ginkgo/ginkgo \
     github.com/hashicorp/packer \
-  && curl -fsSLO https://github.com/alecthomas/gometalinter/releases/download/v${GOMETALINTER_VERSION}/gometalinter-${GOMETALINTER_VERSION}-linux-amd64.tar.gz \
-  && tar xzvf gometalinter-${GOMETALINTER_VERSION}-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin \
-  && ln -s /usr/local/bin/gometalinter /usr/local/bin/gometalinter.v2 \
-  && rm gometalinter-${GOMETALINTER_VERSION}-linux-amd64.tar.gz \
+    gopkg.in/alecthomas/gometalinter.v2 \
+  && ln -s ${GOPATH}/bin/gometalinter.v2 ${GOPATH}/bin/gometalinter \
+  && gometalinter.v2 --install \
   && pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
   && apt-get purge --auto-remove -y libffi-dev python-dev python-pip \
   && apt-get autoremove -y \


### PR DESCRIPTION
Installing from a pre-packaged version of `gometalinter` eventually caused a problem when `go` was upgraded to 1.11 since `goimports` needed to be recompiled. This changes the install method to use the latest stable tag for `gometalinter` and lets `gometalinter --install` fetch and compile `goimports` and friends.

Refs Azure/acs-engine#3763.