### PR TITLE
feat(dockerfile): add a label to the dockerfile

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:16.04
 
+LABEL name="deis-go-dev"
+
 ENV AZCLI_VERSION=2.0.45 \
     GO_VERSION=1.11 \
     GLIDE_VERSION=v0.13.1 \


### PR DESCRIPTION
Because this image is often used in build environments, it's useful to be able to exclude it from things like `docker system prune` by using the `--filter` flag which works on labels. This way, your build system always has the go-dev image available but you still prune old images no longer being used.