### PR TITLE
Migrate linting to use golangci-lint

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -10,7 +10,7 @@ ENV AZCLI_VERSION=2.0.46 \
     KUBECTL_VERSION=v1.9.6 \
     SHELLCHECK_VERSION=v0.4.6 \
     ETCDCTL_VERSION=v3.1.8 \
-    GOLANGCI_LINT_VERSION=v1.10.2 \
+    GOLANGCI_LINT_VERSION=v1.11.2 \
     PATH=$PATH:/usr/local/go/bin:/go/bin:/usr/local/bin/docker \
     GOPATH=/go
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -10,6 +10,7 @@ ENV AZCLI_VERSION=2.0.46 \
     KUBECTL_VERSION=v1.9.6 \
     SHELLCHECK_VERSION=v0.4.6 \
     ETCDCTL_VERSION=v3.1.8 \
+    GOLANGCI_LINT_VERSION=v1.10.2 \
     PATH=$PATH:/usr/local/go/bin:/go/bin:/usr/local/bin/docker \
     GOPATH=/go
 
@@ -89,6 +90,7 @@ RUN \
     gopkg.in/alecthomas/gometalinter.v2 \
   && ln -s ${GOPATH}/bin/gometalinter.v2 ${GOPATH}/bin/gometalinter \
   && gometalinter.v2 --install \
+  && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin $GOLANGCI_LINT_VERSION \
   && pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
   && apt-get purge --auto-remove -y libffi-dev python-dev python-pip \
   && apt-get autoremove -y \


### PR DESCRIPTION
This PR fixes #123 
>Golangci-lint is a faster version of gometalinter and provides more features as well.
>https://github.com/golangci/golangci-lint#performance

The current linting implementation uses gometalinter which has performance disadvantages over golangci-lint. They claim it's down to 'calling the linters directly and reuses work by the parsing program once'. 

From a bit of investigation I have seen it *is* faster. I tried on various projects and saw some good performance improvements. However, they also need to do quite a bit more work with program load times as that's still where the current bottleneck is imo, probably should look into disk cache or something.

Running lint on a current up-to-date fork of the acs-engine repository I got the following:

```
golang-ci
real	1m12.754s
user	0m31.390s
sys	0m29.840s

gometalinter
real	2m29.064s
user	1m40.210s
sys	1m55.470s
```

Where the majority of the time was spent program loading.
```
INFO [load] Program loading took 46.64409s
INFO [load] SSA repr building took 7.7211353s
INFO [runner] worker.1 took 10.1723672s with stages: golint: 10.172265s
INFO [runner] Workers idle times: #2: 1.6234571s
INFO [runner] processing took 39.2069ms with stages: source_code: 32.1093ms, path_prettifier: 1.9079ms, exclude: 955.5µs, max_same_issues: 926.7µs, skip_files: 923.9µs, autogenerated_exclude: 582µs, max_per_file_from_linter: 557.4µs, cgo: 449µs, uniq_by_line: 415.9µs, nolint: 169.7µs, max_from_linter: 119.4µs, diff: 90.2µs
INFO Memory: 216 samples, avg is 1110.6MB, max is 2695.4MB
INFO Execution took 1m7.895888s
```

It's also worth mentioning that dropping in the config and overriding some of the default for `govet` like  `use-installed-packages: false` for example, gave me even further reductions. I just didn't want to add more to this and bundle in yet another dotfile to manage. (I can happily add this though if required)

```
real	0m51.837s
user	0m18.550s
sys	0m27.920s
```

Edit: I forgot to mention that I upped the default deadline as I couldn't even get gometalinter to complete on some projects in 20s before it backed out. (it's a rather old macbook..)

Signed-off-by: Chris M <millscj01@gmail.com>