### PR TITLE
chore(rootfs/Dockerfile): update go toolchain to 1.11.2

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 LABEL name="deis-go-dev"
 
 ENV AZCLI_VERSION=2.0.46 \
-    GO_VERSION=1.11.1 \
+    GO_VERSION=1.11.2 \
     GLIDE_VERSION=v0.13.1 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.6.0 \


### PR DESCRIPTION
See https://golang.org/doc/devel/release.html#go1.11.minor