### PR TITLE
update golangci to the latest release

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -10,7 +10,7 @@ ENV AZCLI_VERSION=2.0.46 \
     KUBECTL_VERSION=v1.9.6 \
     SHELLCHECK_VERSION=v0.4.6 \
     ETCDCTL_VERSION=v3.1.8 \
-    GOLANGCI_LINT_VERSION=v1.11.2 \
+    GOLANGCI_LINT_VERSION=v1.12.5 \
     PATH=$PATH:/usr/local/go/bin:/go/bin:/usr/local/bin/docker \
     GOPATH=/go
 


### PR DESCRIPTION
This version of golangci-lint contains some important fixes for goimports and linting perf improvements.

https://github.com/golangci/golangci-lint/releases/tag/v1.12.5