### PR TITLE
chore(rootfs/Dockerfile): remove cached files

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -99,7 +99,8 @@ RUN \
   && apt-get purge --auto-remove -y libffi-dev python-dev python-pip \
   && apt-get autoremove -y \
   && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc $GOPATH/pkg/* $GOPATH/src/* /root/cache /root/.cache \
+  && go clean -cache -testcache -modcache
 
 WORKDIR /go
 


### PR DESCRIPTION
Removes over 2GB of cached files that were inadvertently built into the Docker image.

```
$ docker images
REPOSITORY             TAG            IMAGE ID        CREATED              SIZE
quay.io/deis/go-dev    before         e8aed44f9cea    5 days ago           3.94GB
quay.io/deis/go-dev    after          2d2b1553095e    About a minute ago   1.82GB
```