### PR TITLE
fix: download shellcheck from the apt-get repo

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -8,7 +8,6 @@ ENV AZCLI_VERSION=2.0.59 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.13.0 \
     KUBECTL_VERSION=v1.10.13 \
-    SHELLCHECK_VERSION=v0.4.6 \
     ETCDCTL_VERSION=v3.1.8 \
     GOLANGCI_LINT_VERSION=v1.15.0 \
     PATH=$PATH:/usr/local/go/bin:/go/bin:/usr/local/bin/docker \
@@ -40,6 +39,7 @@ RUN \
     python-dev \
     python-pip \
     python-setuptools \
+    shellcheck \
     rsync \
     ruby \
     unzip \
@@ -51,8 +51,6 @@ RUN \
   && curl -L https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -sSL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz \
     | tar -vxz -C /usr/local/bin --strip=1 \
-  && curl -L https://deisbuildartifacts.blob.core.windows.net/shellcheck/shellcheck-${SHELLCHECK_VERSION}-linux-amd64 -o /usr/local/bin/shellcheck \
-  && chmod +x /usr/local/bin/shellcheck \
   && curl -L https://storage.googleapis.com/k8s-claimer/git-e4dcc16/k8s-claimer-git-e4dcc16-linux-amd64 -o /usr/local/bin/k8s-claimer \
 	&& chmod +x /usr/local/bin/k8s-claimer \
   && curl -sSL -o /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip \


### PR DESCRIPTION
Shellcheck doesn't seem to exist in `https://deisbuildartifacts.blob.core.windows.net/`.

This PR fixes that by downloading via `apt-get` instead.