### PR TITLE
chore(rootfs/Dockerfile): update shellcheck to v0.6.0

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,6 +12,7 @@ ENV AZCLI_VERSION=2.0.60 \
     ETCDCTL_VERSION=v3.1.8 \
     GOLANGCI_LINT_VERSION=v1.15.0 \
     PROTOBUF_VERSION=3.7.0 \
+    SHELLCHECK_VERSION=v0.6.0 \
     PATH=$PATH:/usr/local/go/bin:/go/bin:/usr/local/bin/docker \
     GOPATH=/go
 
@@ -41,7 +42,6 @@ RUN \
     python-dev \
     python-pip \
     python-setuptools \
-    shellcheck \
     rsync \
     ruby \
     unzip \
@@ -96,6 +96,8 @@ RUN \
   && ln -s ${GOPATH}/bin/gometalinter.v2 ${GOPATH}/bin/gometalinter \
   && gometalinter.v2 --install \
   && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION} \
+  && curl -o /usr/local/bin/shellcheck -sSL https://shellcheck.storage.googleapis.com/shellcheck-${SHELLCHECK_VERSION}.linux-x86_64 \
+  && chmod +x /usr/local/bin/shellcheck \
   && pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
   && apt-get purge --auto-remove -y libffi-dev python-dev python-pip \
   && apt-get autoremove -y \


### PR DESCRIPTION
Installs the latest version of the `shellcheck` binary from their GitHub artifacts.

In #156 we inadvertently regressed the version of `shellcheck` (to v0.3.7 from v0.4.6) because the latest version packaged for Ubuntu is ancient.