### PR TITLE
chore(rootfs/Dockerfile): update go toolchain to 1.12.6

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -4,7 +4,7 @@ LABEL name="deis-go-dev" \
       maintainer="Matt Boersma <matt.boersma@microsoft.com>"
 
 ENV AZCLI_VERSION=2.0.66 \
-    GO_VERSION=1.12.5 \
+    GO_VERSION=1.12.6 \
     GLIDE_VERSION=v0.13.2 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.14.1 \


### PR DESCRIPTION
See https://golang.org/doc/devel/release.html#go1.12.minor