### PR TITLE
chore(rootfs/Dockerfile): update k with recent changes

### DIFF
--- a/rootfs/usr/local/bin/k
+++ b/rootfs/usr/local/bin/k
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set +x
+set +xe
 
 KX_PATH="$HOME/.kx"
 mkdir -p "$KX_PATH/cache"
@@ -28,12 +28,16 @@ fi
 
 # Get the server version from the server if not cached
 if [ -z "$TARGET_VERSION" ]; then
-  TARGET_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion')
+  if [ $(echo $TARGET_VERSION | egrep "alpha|beta|rc") ]; then
+    TARGET_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-4)
+  else
+    TARGET_VERSION=$(kubectl version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion' | cut -d'.' -f1-3)
+  fi
 fi
 
-# Default to kubectl v1.10.12 if TARGET_VERSION was unset and `kubectl version` failed
+# Default to kubectl v1.16.2 if TARGET_VERSION was unset and `kubectl version` failed
 if [ "$TARGET_VERSION" == "null" ]; then
-  TARGET_VERSION=v1.10.12
+  TARGET_VERSION=v1.16.2
 fi
 
 # Fill the cache if possible


### PR DESCRIPTION
See https://github.com/jakepearson/k/pull/5

The merge is needed because docker-go-dev has some tweaks to `k` that haven't made it upstream:
- silent output so as not to upset CI
- fallback `kubectl` version instead of erroring