### PR TITLE
chore(rootfs/Dockerfile): update go toolchain to 1.12.13

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,7 +5,7 @@ LABEL name="deis-go-dev" \
 
 ENV AZCLI_VERSION=2.0.75 \
     DOCKER_VERSION=19.03.4 \
-    GO_VERSION=1.12.12 \
+    GO_VERSION=1.12.13 \
     GLIDE_VERSION=v0.13.3 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.14.3 \


### PR DESCRIPTION
See https://golang.org/doc/devel/release.html#go1.12.minor