### PR TITLE
chore(rootfs/Dockerfile): update go toolchain to 1.13.6

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,7 +5,7 @@ LABEL name="deis-go-dev" \
 
 ENV AZCLI_VERSION=2.0.79 \
     DOCKER_VERSION=19.03.4 \
-    GO_VERSION=1.13.5 \
+    GO_VERSION=1.13.6 \
     GLIDE_VERSION=v0.13.3 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.14.3 \


### PR DESCRIPTION
See https://golang.org/doc/devel/release.html#go1.13.minor