### PR TITLE
chore(rootfs/Dockerfile): update Azure CLI to 2.3.1

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 LABEL name="deis-go-dev" \
       maintainer="Matt Boersma <matt.boersma@microsoft.com>"
 
-ENV AZCLI_VERSION=2.2.0 \
+ENV AZCLI_VERSION=2.3.1 \
     DOCKER_VERSION=19.03.4 \
     GO_VERSION=1.14.1 \
     GLIDE_VERSION=v0.13.3 \
@@ -49,8 +49,9 @@ RUN \
     procps \
     python \
     python-dev \
-    python-pip \
+    python3-pip \
     python-setuptools \
+    python3-setuptools \
     rsync \
     ruby \
     unzip \
@@ -107,8 +108,8 @@ RUN \
   && chmod +x /usr/local/bin/shellcheck \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
-  && pip install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
-  && apt-get purge --auto-remove -y libffi-dev python-dev python-pip \
+  && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
+  && apt-get purge --auto-remove -y libffi-dev python-dev python3-pip \
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc ${GOPATH}/pkg/* ${GOPATH}/src/* /root/cache /root/.cache \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -47,10 +47,9 @@ RUN \
     netcat \
     openssh-client \
     procps \
-    python \
-    python-dev \
+    python3 \
+    python3-dev \
     python3-pip \
-    python-setuptools \
     python3-setuptools \
     rsync \
     ruby \
@@ -109,7 +108,7 @@ RUN \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
   && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
-  && apt-get purge --auto-remove -y libffi-dev python-dev python3-pip \
+  && apt-get purge --auto-remove -y libffi-dev python3-dev python3-pip \
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc ${GOPATH}/pkg/* ${GOPATH}/src/* /root/cache /root/.cache \


### PR DESCRIPTION
This requires using `pip3`. Installing az-cli 2.3.x fails with 

```
Collecting mock~=4.0 (from azure-cli)
  Could not find a version that satisfies the requirement mock~=4.0 (from azure-cli) (from versions: 0.5.0, 0.6.0, 0.7.0b1, 0.7.0b2, 0.7.0b3, 0.7.0b4, 0.7.0rc1, 0.7.0, 0.7.1, 0.7.2, 0.8.0, 1.0b1, 1.0.0, 1.0.1, 1.1.0, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.2.0, 1.3.0, 2.0.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5)
No matching distribution found for mock~=4.0 (from azure-cli)
```

According to https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?view=azure-cli-latest#prerequisites, "The CLI has dropped support for Python 2.7 since version 2.1.0. New versions no longer guarantee to run with Python 2.7 correctly."