### PR TITLE
chore(rootfs/Dockerfile): update go toolchain to 1.14.2

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,7 +5,7 @@ LABEL name="deis-go-dev" \
 
 ENV AZCLI_VERSION=2.2.0 \
     DOCKER_VERSION=19.03.4 \
-    GO_VERSION=1.14.1 \
+    GO_VERSION=1.14.2 \
     GLIDE_VERSION=v0.13.3 \
     GLIDE_HOME=/root \
     HELM_VERSION=v2.16.3 \


### PR DESCRIPTION
See https://github.com/golang/go/issues?q=milestone%3AGo1.14.2+label%3ACherryPickApproved