### PR TITLE
chore(rootfs/Dockerfile): retain python3-pip in the image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -108,7 +108,7 @@ RUN \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
   && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml \
-  && apt-get purge --auto-remove -y libffi-dev python3-dev python3-pip \
+  && apt-get purge --auto-remove -y libffi-dev python3-dev \
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc ${GOPATH}/pkg/* ${GOPATH}/src/* /root/cache /root/.cache \


### PR DESCRIPTION
Retain python3-pip package so that az extensions can be added.
Example: `az extension add --name azure-devops`
Fixes #227.