### PR TITLE
chore(rootfs/Dockerfile): update Azure CLI version to 2.17.1

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -4,7 +4,8 @@ LABEL name="deis-go-dev" \
       maintainer="Matt Boersma <matt.boersma@microsoft.com>"
 
 ENV ANSIBLE_VERSION=2.10.3 \
-    AZCLI_VERSION=2.12.1 \
+    AZCLI_VERSION=2.17.1 \
+    PYJWT_VERSION=1.7.1 \
     DOCKER_VERSION=20.10.2 \
     GO_VERSION=1.15.5 \
     GLIDE_VERSION=v0.13.3 \
@@ -109,7 +110,7 @@ RUN \
     && unzip /tmp/packer.zip -d /usr/local/bin \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
-  && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} shyaml ansible==${ANSIBLE_VERSION} pywinrm==${PYWINRM_VERSION} \
+  && pip3 install --disable-pip-version-check --no-cache-dir azure-cli==${AZCLI_VERSION} PyJWT==${PYJWT_VERSION} shyaml ansible==${ANSIBLE_VERSION} pywinrm==${PYWINRM_VERSION} \
   && apt-get purge --auto-remove -y libffi-dev python3-dev \
   && apt-get autoremove -y \
   && apt-get clean -y \


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Also need to specify `PyJWT` version since Azure CLI will install `PyJWT` 2.0.0, which breaks `az login -i`.