### PR TITLE
chore(rootfs/Dockerfile): remove deprecated Go projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,10 @@ creating [issues][] and submitting [pull requests][].
 * based on [Ubuntu 18.04][]
 * [az][]: Azure cloud command-line tool
 * [azcopy][]: Utility for copying data to/from Microsoft Azure Blob and File storage
-* [dep][]: Go dependency management tool
 * [delve][]: debugger for the Go programming language
 * [Docker][]: Docker binaries to be able to bind mount /var/run/docker.sock in the dev environment container
-* [gb][]: project-based build tool for Go
 * [ginkgo][]: BDD testing framework for Go
-* [glide][]: Go dependency management tool
 * [go-bindata][]: converts any file into Go source code
-* [golint][]: Go source code linter
-* [gometalinter][]: run Go lint tools concurrently
 * [golangci-lint][]: concurrent runner for Go linting tools
 * [gox][]: simple Go cross-compiling tool
 * [helm][]: Kubernetes package manager
@@ -43,14 +38,14 @@ creating [issues][] and submitting [pull requests][].
 ## Usage
 
 Mount your local Go code into a container's `$GOPATH` to run any `go` command or one of the
-included tools or scripts. Here's an example of running `glide up` for deis/builder:
+included tools or scripts. Here's an example of running `ginko` for deis/builder:
 
 ```console
 $ docker run --rm \
   --volume $GOPATH/src/github.com/deis/builder:/go/src/github.com/deis/builder \
   --workdir /go/src/github.com/deis/builder \
   quay.io/deis/go-dev:latest \
-  glide up
+  ginkgo -r
 ```
 
 ## Releases
@@ -87,18 +82,13 @@ You will be prompted to confirm again before any tag or release is written to Gi
 [az]: https://github.com/Azure/azure-cli#readme
 [azcopy]: https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-linux?toc=%2fazure%2fstorage%2ffiles%2ftoc.json
 [deisrel]: https://github.com/deis/deisrel
-[delve]: https://github.com/derekparker/delve
-[dep]: https://github.com/golang/dep
+[delve]: https://github.com/go-delve/delve
 [Docker Hub]: https://hub.docker.com
 [Docker]: http://www.docker.com
-[gb]: https://github.com/constabulary/gb/
 [gen-changelog.sh]: https://github.com/deis/docker-go-dev/tree/master/rootfs/usr/local/bin/gen-changelog.sh
 [ginkgo]: https://github.com/onsi/ginkgo
-[glide]: https://github.com/Masterminds/glide
 [go-bindata]: https://github.com/jteeuwen/go-bindata
 [Go]: https://golang.org/
-[golint]: https://github.com/golang/lint
-[gometalinter]: https://github.com/alecthomas/gometalinter
 [golangci-lint]: https://github.com/golangci/golangci-lint
 [gox]: https://github.com/mitchellh/gox
 [helm]: https://github.com/kubernetes/helm

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,17 +5,15 @@ LABEL name="deis-go-dev" \
 
 ENV ANSIBLE_VERSION=2.10.3 \
     AZCLI_VERSION=2.17.1 \
-    PYJWT_VERSION=1.7.1 \
     DOCKER_VERSION=20.10.2 \
+    ETCDCTL_VERSION=v3.1.8 \
     GO_VERSION=1.15.8 \
-    GLIDE_VERSION=v0.13.3 \
-    GLIDE_HOME=/root \
+    GOLANGCI_LINT_VERSION=v1.31.0 \
     HELM_VERSION=3.5.0 \
     KUBECTL_VERSION=v1.16.3 \
-    ETCDCTL_VERSION=v3.1.8 \
-    GOLANGCI_LINT_VERSION=v1.31.0 \
     PACKER_VERSION=1.6.1 \
     PROTOBUF_VERSION=3.7.0 \
+    PYJWT_VERSION=1.7.1 \
     PYWINRM_VERSION=0.4.1 \
     SHELLCHECK_VERSION=v0.7.1 \
     SHFMT_VERSION=3.1.2 \
@@ -64,8 +62,6 @@ RUN \
     yq \
     zip \
   && curl -L https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xz \
-  && curl -sSL https://github.com/Masterminds/glide/releases/download/${GLIDE_VERSION}/glide-${GLIDE_VERSION}-linux-amd64.tar.gz \
-    | tar -vxz -C /usr/local/bin --strip=1 \
   && curl -sSL -o /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip \
   && unzip /tmp/protoc.zip 'bin/protoc' -d /usr/local \
   && rm /tmp/protoc.zip \
@@ -76,7 +72,6 @@ RUN \
   && chmod 700 get_helm.sh && ./get_helm.sh --version v${HELM_VERSION} \
   && rm ./get_helm.sh \
   && mkdir -p /go/bin \
-  && curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
   && curl -sSL https://aka.ms/downloadazcopy-v10-linux | tar -vxz -C /usr/local/bin --strip=1 \
   && mv /usr/local/bin/azcopy /usr/local/bin/azcopy-preview \
   && curl -sSL https://aka.ms/downloadazcopylinux64 | tar -vxz -C /tmp \
@@ -93,7 +88,6 @@ RUN \
   && go get -u -v \
     github.com/AlekSi/gocov-xml \
     github.com/axw/gocov/gocov \
-    github.com/constabulary/gb/... \
     github.com/go-delve/delve/cmd/dlv \
     github.com/dgrijalva/jwt-go/cmd/jwt \
     github.com/golang/protobuf/protoc-gen-go \
@@ -101,9 +95,6 @@ RUN \
     github.com/jteeuwen/go-bindata/... \
     github.com/mitchellh/gox \
     github.com/onsi/ginkgo/ginkgo \
-    gopkg.in/alecthomas/gometalinter.v2 \
-  && ln -s ${GOPATH}/bin/gometalinter.v2 ${GOPATH}/bin/gometalinter \
-  && gometalinter.v2 --install \
   && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION} \
   && curl -sSL https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
     | tar -vxJ -C /usr/local/bin --strip=1 \


### PR DESCRIPTION
Fixes #257

Note that AKS Engine still relies on `go-bindata`, so that needs to stay. Helm 3 replaced 2 in #262.