### PR TITLE
chore(Dockerfile): updates from team hephy

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL name="deis-go-dev" \
       maintainer="Matt Boersma <matt.boersma@microsoft.com>"
@@ -40,7 +40,7 @@ RUN \
     git-core \
     jq \
     libffi-dev \
-    libicu60 \
+    libc6 \
     libssl-dev \
     libunwind8 \
     man \

--- a/rootfs/usr/local/bin/lint
+++ b/rootfs/usr/local/bin/lint
@@ -2,21 +2,25 @@
 
 # Mandatory tests
 echo -e "\033[0;31mManadatory Linters: These must pass\033[0m"
-gometalinter --vendor --tests --deadline=20s --disable-all \
+golangci-lint run --modules-download-mode=vendor --tests --deadline=20s --disable-all \
 --enable=gofmt \
 --enable=misspell \
 --enable=deadcode \
 --enable=ineffassign \
 --enable=gosimple \
---enable=vet \
+--enable=govet \
+--enable=typecheck \
 ./...
 
 mandatory=$?
 
 # Optional tests
 echo -e "\033[0;32mOptional Linters: These should pass\033[0m"
-gometalinter --vendor --tests --deadline=20s --disable-all \
---enable=golint \
+golangci-lint run --modules-download-mode=vendor --tests --deadline=20s --disable-all \
+--enable=revive \
+--enable=gosec \
+--enable=gocognit \
+--enable=gocritic \
 ./...
 
 exit $mandatory


### PR DESCRIPTION
 - update base image to `ubuntu:20.04` focal lts
 - switch to `golangci-lint` for linter as `gometalinter` is DEPRECATED
 - `golint` is DEPRECATED in favor of drop-in replacement `revive`
 - enable `typecheck` linter as mandatory (pretty quiet linter)
 - enable `gosec`, `gocritic`, and `gocognit` as optional linters
   (useful)
 - drop library `libicu60` for library `libc6` that exists in focal

Signed-off-by: Cryptophobia <aouzounov@gmail.com>