### PR TITLE
fix(rootfs/Dockerfile): update ansible to 4.2.0 to fix windows

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 LABEL name="deis-go-dev" \
       maintainer="Matt Boersma <matt.boersma@microsoft.com>"
 
-ENV ANSIBLE_VERSION=2.10.11 \
+ENV ANSIBLE_VERSION=4.2.0 \
     AZCLI_VERSION=2.26.1 \
     DOCKER_VERSION=20.10.2 \
     ETCDCTL_VERSION=v3.1.8 \
@@ -111,8 +111,9 @@ RUN \
   && tar -xvf /tmp/upx.tar.xz -C /tmp \
   && mv /tmp/upx-${UPX_VERSION}-amd64_linux/upx /usr/local/bin/upx \
   && pip3 install --disable-pip-version-check --no-cache-dir --upgrade pip \
-  && pip3 install --disable-pip-version-check --no-cache-dir --upgrade azure-cli==${AZCLI_VERSION} PyJWT==${PYJWT_VERSION} shyaml ansible-base==${ANSIBLE_VERSION} pywinrm==${PYWINRM_VERSION} \
-  && ansible-galaxy collection install ansible.windows \
+  && pip3 install --disable-pip-version-check --no-cache-dir --upgrade azure-cli==${AZCLI_VERSION} PyJWT==${PYJWT_VERSION} shyaml pywinrm==${PYWINRM_VERSION} \
+  && pip3 install --disable-pip-version-check --no-cache-dir --upgrade ansible==4.2.0 ansible-core --force-reinstall \
+  && ansible-galaxy collection install ansible.windows:==1.7.0 \
   && apt-get purge --auto-remove -y libffi-dev python3-dev \
   && apt-get autoremove -y \
   && apt-get clean -y \


### PR DESCRIPTION
Had to do some thrashing around to find a packaged ansible that fixes all the issues around `ansible.windows` and cloud-init. This seems to work, as tested on an internal Azure pipeline.

cc: @jsturtevant 