### PR TITLE
chore(rootfs/Dockerfile): remove yq tool

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -28,9 +28,6 @@ RUN \
   sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get update && \
-  apt-get install -y software-properties-common && \
-  add-apt-repository ppa:rmescandon/yq && \
-  apt-get update && \
   apt-get upgrade -y --no-install-recommends && \
   apt-get install -y --no-install-recommends \
     bash \
@@ -60,7 +57,6 @@ RUN \
     vim \
     wamerican \
     wget \
-    yq \
     zip \
   && curl -L https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -sSL -o /tmp/protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protoc-${PROTOBUF_VERSION}-linux-x86_64.zip \


### PR DESCRIPTION
This seems to have broken since the last time we did a go-dev release:

```shell
% docker run -it ubuntu:20.04 bash
root@c8b90ef772d4:/# apt-get update && apt-get install yq 
Get:1 http://ports.ubuntu.com/ubuntu-ports focal InRelease [265 kB]
Get:2 http://ports.ubuntu.com/ubuntu-ports focal-updates InRelease [114 kB]
Get:3 http://ports.ubuntu.com/ubuntu-ports focal-backports InRelease [101 kB]
Get:4 http://ports.ubuntu.com/ubuntu-ports focal-security InRelease [114 kB]
Get:5 http://ports.ubuntu.com/ubuntu-ports focal/universe arm64 Packages [11.1 MB]
Get:6 http://ports.ubuntu.com/ubuntu-ports focal/restricted arm64 Packages [1317 B]
Get:7 http://ports.ubuntu.com/ubuntu-ports focal/multiverse arm64 Packages [139 kB]
Get:8 http://ports.ubuntu.com/ubuntu-ports focal/main arm64 Packages [1234 kB]
Get:9 http://ports.ubuntu.com/ubuntu-ports focal-updates/main arm64 Packages [1162 kB]
Get:10 http://ports.ubuntu.com/ubuntu-ports focal-updates/universe arm64 Packages [1020 kB]
Get:11 http://ports.ubuntu.com/ubuntu-ports focal-updates/restricted arm64 Packages [3329 B]
Get:12 http://ports.ubuntu.com/ubuntu-ports focal-updates/multiverse arm64 Packages [8778 B]
Get:13 http://ports.ubuntu.com/ubuntu-ports focal-backports/universe arm64 Packages [6308 B]
Get:14 http://ports.ubuntu.com/ubuntu-ports focal-backports/main arm64 Packages [2680 B]
Get:15 http://ports.ubuntu.com/ubuntu-ports focal-security/restricted arm64 Packages [3087 B]
Get:16 http://ports.ubuntu.com/ubuntu-ports focal-security/universe arm64 Packages [734 kB]
Get:17 http://ports.ubuntu.com/ubuntu-ports focal-security/multiverse arm64 Packages [3243 B]
Get:18 http://ports.ubuntu.com/ubuntu-ports focal-security/main arm64 Packages [747 kB]
Fetched 16.8 MB in 2s (10.3 MB/s)                          
Reading package lists... Done
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package yq
```

Maybe we can remove it? If that causes problems, I can investigate installing it via a [different method](https://github.com/mikefarah/yq#install). cc: @MaurGi @sgoings ?

See also #195.