### PR TITLE
Fix for Dockerfile smell DL3015

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -28,7 +28,7 @@ RUN \
   sed -i -e 's/^deb-src/#deb-src/' /etc/apt/sources.list && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get update && \
-  apt-get install -y software-properties-common && \
+  apt-get install --no-install-recommends -y software-properties-common && \
   add-apt-repository ppa:rmescandon/yq && \
   apt-get update && \
   apt-get upgrade -y --no-install-recommends && \
@@ -77,7 +77,7 @@ RUN \
   && mv /usr/local/bin/azcopy /usr/local/bin/azcopy-preview \
   && curl -sSL https://aka.ms/downloadazcopylinux64 | tar -vxz -C /tmp \
   && /tmp/install.sh \
-  && apt-get update && apt-get -f -y install \
+  && apt-get update && apt-get -f -y install --no-install-recommends \
   && curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \
   && tar xzvf docker-${DOCKER_VERSION}.tgz -C /usr/local/bin \
   && chmod +x -R /usr/local/bin/docker \


### PR DESCRIPTION
Hi!
The Dockerfile placed at "rootfs/Dockerfile" contains the best practice violation [DL3015](https://github.com/hadolint/hadolint/wiki/DL3015) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3015 occurs when the apt tool is used to install packages without the "--no-install-recommends" flag. This flag is recommended to be used to avoid installing additional packages not explicitly requested.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the "--no-install-recommends" flag is added to the apt-get install command.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance