### PR TITLE
fix(rootfs/Dockerfile): update golangci-lint installation script

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -95,7 +95,7 @@ RUN \
   && go install -v github.com/haya14busa/goverage@latest \
   && go install -v github.com/mitchellh/gox@latest \
   && go install -v github.com/onsi/ginkgo/ginkgo@v1.16.5 \
-  && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION} \
+  && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION} \
   && curl -sSL https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz \
   | tar -vxJ -C /usr/local/bin --strip=1 \
   && curl -sSL https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip -o /tmp/packer.zip \


### PR DESCRIPTION
Hi!

`install.goreleaser.com` [was deprecated a long time ago](https://goreleaser.com/deprecations/#godownloader) and now it's completely removed:

```
$ curl install.goreleaser.com
curl: (6) Could not resolve host: install.goreleaser.com
```

As a result, the `latest` image doesn't contain `golangci-lint` anymore:

```
$ docker run -it --rm quay.io/deis/go-dev:latest golangci-lint --version
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "golangci-lint": executable file not found in $PATH: unknown.
```

For example, one of old images:

```
$ docker run -it --rm quay.io/deis/go-dev:v1.34.4 golangci-lint --version
golangci-lint has version 1.44.0 built from 617470fa on 2022-01-25T11:31:17Z
```

So, I suggest to update `Dockerfile` according to [golangci-lint docs](https://golangci-lint.run/usage/install/#binaries).