### PR TITLE
goss dev's repo was changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You will be prompted to confirm again before any tag or release is written to Gi
 [Go]: https://golang.org/
 [go-dev index URL]: https://mcr.microsoft.com/v2/oss/azcu/go-dev/tags/list
 [golangci-lint]: https://github.com/golangci/golangci-lint
-[goss]: https://github.com/aelsabbahy/goss
+[goss]: https://github.com/goss-org/goss
 [gox]: https://github.com/mitchellh/gox
 [helm]: https://github.com/kubernetes/helm
 [issues]: https://github.com/deis/docker-go-dev/issues

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -100,9 +100,9 @@ RUN \
   && unzip /tmp/packer.zip -d /usr/local/bin \
   && curl -o /usr/local/bin/shfmt -sSL https://github.com/mvdan/sh/releases/download/v{SHFMT_VERSION}/shfmt_v{SHFMT_VERSION}_linux_amd64 \
   && chmod +x /usr/local/bin/shfmt \
-  && curl -L "https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64" -o /usr/local/bin/goss \
+  && curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64" -o /usr/local/bin/goss \
   && chmod +rx /usr/local/bin/goss \
-  && curl -L "https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/dgoss" -o /usr/local/bin/dgoss \
+  && curl -L "https://github.com/goss-org/goss/releases/download/${GOSS_VERSION}/dgoss" -o /usr/local/bin/dgoss \
   && chmod +rx /usr/local/bin/dgoss \
   && curl -sSL -o /tmp/upx.tar.xz https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz \
   && tar -xvf /tmp/upx.tar.xz -C /tmp \


### PR DESCRIPTION
since the goss developer repository was changed (goss-org/goss) and to avoid repojacking